### PR TITLE
Fix build workflow syntax

### DIFF
--- a/.github/workflows/build_addon.yml
+++ b/.github/workflows/build_addon.yml
@@ -1,4 +1,4 @@
-      name: build addon
+name: build addon
 
 on:
   push:


### PR DESCRIPTION
## Summary
- Fix the top-level `name:` key in `.github/workflows/build_addon.yml` so the workflow is valid again.
- Checked the workflows directory; `build_addon.yml` is the only workflow file.

## Validation
- `uv run pre-commit run check-yaml --files .github\workflows\build_addon.yml`
- Parsed the workflow with PyYAML `BaseLoader` and confirmed top-level `name`, `on`, and `jobs` keys are present.
- `git diff --check HEAD~1..HEAD`