### PR TITLE
Fix DPAPI secure storage handling

### DIFF
--- a/addon/globalPlugins/xyOCR/__init__.py
+++ b/addon/globalPlugins/xyOCR/__init__.py
@@ -109,9 +109,14 @@ class XinyiOcrSettingsPanel(gui.settingsDialogs.SettingsPanel):
 		self.nvdacnPassCtrl = nvdacnGroup.addLabeledControl(
 			_(nvdacnPassLabel), wx.TextCtrl, style=wx.TE_PASSWORD
 		)
-		encrypted_password = config.conf["xinyiOcr"]["nvdacn_account"]["password"]
-		self.original_decrypted_password = decrypt(encrypted_password)
-		self.nvdacnPassCtrl.SetValue(self.original_decrypted_password)
+		self.original_encrypted_password = config.conf["xinyiOcr"]["nvdacn_account"]["password"]
+		self.original_decrypted_password = decrypt(self.original_encrypted_password)
+		self.nvdacn_password_decrypt_failed = self.original_decrypted_password is None
+		if self.nvdacn_password_decrypt_failed:
+			log.warning("DPAPI: Failed to decrypt the stored NVDACN password; keeping the existing value.")
+			self.original_decrypted_password = ""
+		else:
+			self.nvdacnPassCtrl.SetValue(self.original_decrypted_password)
 
 	def onSave(self):
 		# 保存配置
@@ -124,8 +129,15 @@ class XinyiOcrSettingsPanel(gui.settingsDialogs.SettingsPanel):
 		config.conf["xinyiOcr"]["IDG"]["prompt"] = self.idgPromptTextCtrl.GetValue()
 		config.conf["xinyiOcr"]["nvdacn_account"]["user"] = self.nvdacnUserCtrl.GetValue()
 		current_password_input = self.nvdacnPassCtrl.GetValue()
-		if current_password_input != self.original_decrypted_password:
-			config.conf["xinyiOcr"]["nvdacn_account"]["password"] = encrypt(current_password_input)
+		if self.nvdacn_password_decrypt_failed and not current_password_input:
+			config.conf["xinyiOcr"]["nvdacn_account"]["password"] = self.original_encrypted_password
+		elif current_password_input != self.original_decrypted_password:
+			encrypted_password = encrypt(current_password_input)
+			if encrypted_password is None:
+				log.error("DPAPI: Failed to encrypt the NVDACN password; keeping the existing value.")
+				config.conf["xinyiOcr"]["nvdacn_account"]["password"] = self.original_encrypted_password
+			else:
+				config.conf["xinyiOcr"]["nvdacn_account"]["password"] = encrypted_password
 
 
 # Translators: Script description

--- a/addon/globalPlugins/xyOCR/secure_storage.py
+++ b/addon/globalPlugins/xyOCR/secure_storage.py
@@ -1,92 +1,144 @@
 # coding=utf-8
 
-# A module for encrypting and decrypting data using
-# the Windows Data Protection API (DPAPI).
+"""Encrypt and decrypt secrets with Windows DPAPI."""
 
 import base64
-from ctypes import byref, create_string_buffer, c_void_p, Structure, windll, cast
-from ctypes.wintypes import DWORD
+import ctypes
+from ctypes import wintypes
+
 from logHandler import log
 
-# --- CTypes Setup for Windows API ---
+
+class DATA_BLOB(ctypes.Structure):
+	"""Windows DATA_BLOB structure used by DPAPI."""
+
+	_fields_ = [
+		("cbData", wintypes.DWORD),
+		("pbData", ctypes.POINTER(ctypes.c_ubyte)),
+	]
 
 
-class DATA_BLOB(Structure):
-	"""Represents the Windows DATA_BLOB structure."""
-
-	_fields_ = [("cbData", DWORD), ("pbData", c_void_p)]
-
-
-# Define function prototypes for the Windows API calls
-CryptProtectData = windll.crypt32.CryptProtectData
-CryptUnprotectData = windll.crypt32.CryptUnprotectData
-LocalFree = windll.kernel32.LocalFree
-
-# Constants
 CRYPTPROTECT_UI_FORBIDDEN = 0x01
-# A description for the encrypted data, useful for debugging.
 DATA_DESCRIPTION = "Xinyi OCR Add-on Password"
 
+_crypt32 = ctypes.WinDLL("crypt32", use_last_error=True)
+_kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
 
-def encrypt(plain_text: str) -> str:
+_CryptProtectData = _crypt32.CryptProtectData
+_CryptProtectData.argtypes = [
+	ctypes.POINTER(DATA_BLOB),
+	wintypes.LPCWSTR,
+	ctypes.POINTER(DATA_BLOB),
+	wintypes.LPVOID,
+	wintypes.LPVOID,
+	wintypes.DWORD,
+	ctypes.POINTER(DATA_BLOB),
+]
+_CryptProtectData.restype = wintypes.BOOL
+
+_CryptUnprotectData = _crypt32.CryptUnprotectData
+_CryptUnprotectData.argtypes = [
+	ctypes.POINTER(DATA_BLOB),
+	ctypes.POINTER(wintypes.LPWSTR),
+	ctypes.POINTER(DATA_BLOB),
+	wintypes.LPVOID,
+	wintypes.LPVOID,
+	wintypes.DWORD,
+	ctypes.POINTER(DATA_BLOB),
+]
+_CryptUnprotectData.restype = wintypes.BOOL
+
+_LocalFree = _kernel32.LocalFree
+_LocalFree.argtypes = [wintypes.HLOCAL]
+_LocalFree.restype = wintypes.HLOCAL
+
+
+def _last_error_message() -> str:
+	error_code = ctypes.get_last_error()
+	if not error_code:
+		return "unknown error"
+	return f"{error_code}: {ctypes.FormatError(error_code)}"
+
+
+def _bytes_to_blob(data: bytes):
+	buffer = ctypes.create_string_buffer(data, len(data))
+	return DATA_BLOB(len(data), ctypes.cast(buffer, ctypes.POINTER(ctypes.c_ubyte))), buffer
+
+
+def _blob_to_bytes(blob: DATA_BLOB) -> bytes:
+	if not blob.pbData or not blob.cbData:
+		return b""
+	return ctypes.string_at(blob.pbData, blob.cbData)
+
+
+def _free_blob(blob: DATA_BLOB) -> None:
+	if blob.pbData:
+		_LocalFree(ctypes.cast(blob.pbData, wintypes.HLOCAL))
+
+
+def encrypt(plain_text: str) -> str | None:
 	"""
-	Encrypts a string using the Windows DPAPI and returns a Base64 encoded string.
-	If encryption fails for any reason, returns an empty string.
+	Encrypt a string using Windows DPAPI and return a Base64 encoded string.
+
+	Returns an empty string for an intentionally empty secret, and None if encryption fails.
 	"""
 	if not plain_text:
 		return ""
 
+	blob_out = DATA_BLOB()
 	try:
 		data_in = plain_text.encode("utf-8")
-		buffer_in = create_string_buffer(data_in)
-		pointer_in = cast(buffer_in, c_void_p)
-		blob_in = DATA_BLOB(len(data_in), pointer_in)
-		blob_out = DATA_BLOB()
+		blob_in, _buffer_in = _bytes_to_blob(data_in)
 
-		if CryptProtectData(
-			byref(blob_in), DATA_DESCRIPTION, None, None, None, CRYPTPROTECT_UI_FORBIDDEN, byref(blob_out)
+		if not _CryptProtectData(
+			ctypes.byref(blob_in),
+			DATA_DESCRIPTION,
+			None,
+			None,
+			None,
+			CRYPTPROTECT_UI_FORBIDDEN,
+			ctypes.byref(blob_out),
 		):
-			encrypted_data = create_string_buffer(blob_out.cbData)
-			windll.kernel32.RtlMoveMemory(encrypted_data, blob_out.pbData, blob_out.cbData)
-			LocalFree(blob_out.pbData)
-			# Return as a Base64 encoded string for safe storage in config files
-			return base64.b64encode(encrypted_data.raw).decode("utf-8")
-		else:
-			log.error("DPAPI: CryptProtectData failed.")
-			return ""
+			log.error(f"DPAPI: CryptProtectData failed: {_last_error_message()}")
+			return None
+
+		return base64.b64encode(_blob_to_bytes(blob_out)).decode("ascii")
 	except Exception as e:
 		log.error(f"DPAPI: An exception occurred during encryption: {e}", exc_info=True)
-		return ""
+		return None
+	finally:
+		_free_blob(blob_out)
 
 
-def decrypt(encrypted_text: str) -> str:
+def decrypt(encrypted_text: str) -> str | None:
 	"""
-	Decrypts a Base64 encoded string that was encrypted using the Windows DPAPI.
-	If decryption fails (e.g., data is corrupt, from another user/machine),
-	returns an empty string.
+	Decrypt a Base64 encoded DPAPI value.
+
+	Returns an empty string for an empty stored value, and None if decryption fails.
 	"""
 	if not encrypted_text:
 		return ""
 
+	blob_out = DATA_BLOB()
 	try:
-		data_in = base64.b64decode(encrypted_text.encode("utf-8"))
-		buffer_in = create_string_buffer(data_in)
-		pointer_in = cast(buffer_in, c_void_p)
-		blob_in = DATA_BLOB(len(data_in), pointer_in)
-		blob_out = DATA_BLOB()
+		data_in = base64.b64decode(encrypted_text.encode("ascii"), validate=True)
+		blob_in, _buffer_in = _bytes_to_blob(data_in)
 
-		if CryptUnprotectData(
-			byref(blob_in), None, None, None, None, CRYPTPROTECT_UI_FORBIDDEN, byref(blob_out)
+		if not _CryptUnprotectData(
+			ctypes.byref(blob_in),
+			None,
+			None,
+			None,
+			None,
+			CRYPTPROTECT_UI_FORBIDDEN,
+			ctypes.byref(blob_out),
 		):
-			decrypted_data = create_string_buffer(blob_out.cbData)
-			windll.kernel32.RtlMoveMemory(decrypted_data, blob_out.pbData, blob_out.cbData)
-			LocalFree(blob_out.pbData)
-			return decrypted_data.raw.decode("utf-8")
-		else:
-			# This is an expected failure if config is moved to another machine.
-			log.warning("DPAPI: CryptUnprotectData failed. This is normal if config was migrated.")
-			return ""
+			log.warning(f"DPAPI: CryptUnprotectData failed: {_last_error_message()}")
+			return None
+
+		return _blob_to_bytes(blob_out).decode("utf-8")
 	except Exception as e:
-		# This can happen if the data is corrupt or not valid Base64.
-		log.warning(f"DPAPI: An exception occurred during decryption: {e}")
-		return ""
+		log.warning(f"DPAPI: An exception occurred during decryption: {e}", exc_info=True)
+		return None
+	finally:
+		_free_blob(blob_out)

--- a/addon/globalPlugins/xyOCR/vivoOcr.py
+++ b/addon/globalPlugins/xyOCR/vivoOcr.py
@@ -97,6 +97,10 @@ class VivoOcr(ocr.Ocr):
 			user = config.conf["xinyiOcr"]["nvdacn_account"]["user"]
 			encrypted_password = config.conf["xinyiOcr"]["nvdacn_account"]["password"]
 			password = decrypt(encrypted_password)
+			if password is None:
+				log.error("Vivo OCR: NVDACN password failed to decrypt.")
+				ui.message(_("Please configure your NVDACN account in Xinyi OCR settings."))
+				return
 
 			if not user or not password:
 				log.error("Vivo OCR: NVDACN credentials are not configured or failed to decrypt.")


### PR DESCRIPTION
## Summary
- Refactor DPAPI secure storage to declare WinAPI prototypes explicitly for x86/x64 safety.
- Return `None` for encryption/decryption failures so callers can distinguish failures from intentionally empty passwords.
- Preserve the existing stored NVDACN password when decryption or re-encryption fails.

## Validation
- `uv run ruff check addon\globalPlugins\xyOCR\secure_storage.py addon\globalPlugins\xyOCR\__init__.py addon\globalPlugins\xyOCR\vivoOcr.py`
- `python -m compileall addon\globalPlugins\xyOCR`
- Local DPAPI encrypt/decrypt round trip: `DPAPI OK`
- `git diff --check`
- `scons`

No broad formatter was applied; the change is limited to the DPAPI module and its two callers.